### PR TITLE
Support Carthage

### DIFF
--- a/SimplyLayout.xcodeproj/xcshareddata/xcschemes/SimplyLayout.xcscheme
+++ b/SimplyLayout.xcodeproj/xcshareddata/xcschemes/SimplyLayout.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2394161B1F6B86FD003C9B80"
+               BuildableName = "SimplyLayout.framework"
+               BlueprintName = "SimplyLayout"
+               ReferencedContainer = "container:SimplyLayout.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2394161B1F6B86FD003C9B80"
+            BuildableName = "SimplyLayout.framework"
+            BlueprintName = "SimplyLayout"
+            ReferencedContainer = "container:SimplyLayout.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Support Carthage 

## What has changed 
Do what Carthage [tutorial](https://github.com/Carthage/Carthage#supporting-carthage-for-your-framework) says
Add `xcscheme` to repository in order to let Carthage build `SimplyLayout`,
because current project doesn't contain `xcscheme`, so when we build for Carthage, it'll emit an error: 

![Screen Shot 2021-06-25 at 17 09 18](https://user-images.githubusercontent.com/2656519/123401615-88857800-d5d9-11eb-8963-f1c6ca0b6d6c.png)

Solution: https://stackoverflow.com/a/35111518/837499